### PR TITLE
ci: add Claude Code GitHub App workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude.yml` to enable the Claude Code GitHub App
- Triggers on `@claude` mentions in issue comments, PR review comments, and new issues
- Requires `ANTHROPIC_API_KEY` secret to be set in repository settings

## Setup reminder

Make sure `ANTHROPIC_API_KEY` is added to **Settings → Secrets and variables → Actions** in this repo.

## Test

After merging, comment `@claude hello` on any issue to verify it works.